### PR TITLE
Changed LocationSimulator(InputStream) from private to public

### DIFF
--- a/source/MilitaryAppsLibrary/src/com/esri/militaryapps/model/LocationSimulator.java
+++ b/source/MilitaryAppsLibrary/src/com/esri/militaryapps/model/LocationSimulator.java
@@ -166,7 +166,14 @@ public class LocationSimulator extends LocationProvider {
                 );
     }
 
-    private LocationSimulator(final InputStream gpxInputStream) throws ParserConfigurationException, SAXException, IOException {
+    /**
+     * Creates a new LocationSimulator based on an InputStream containing GPX-formatted data.
+     * @param gpxInputStream the GPX input.
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     * @throws IOException
+     */
+    public LocationSimulator(final InputStream gpxInputStream) throws ParserConfigurationException, SAXException, IOException {
         final GPXHandler handler = new GPXHandler();
         locations = new ArrayList<Location>();
         new Thread() {


### PR DESCRIPTION
There's no reason to keep this private. This change makes
LocationSimulator more flexible because it can be instantiated with an
InputStream.
