### PR TITLE
Removed import on demand for JUnit

### DIFF
--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/LocationControllerTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/LocationControllerTest.java
@@ -29,7 +29,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 import org.xml.sax.SAXException;
 
 /**
@@ -90,9 +90,9 @@ public class LocationControllerTest {
             Logger.getLogger(LocationControllerTest.class.getName()).log(Level.SEVERE, null, ex);
         }
         synchronized (locations) {
-            assertTrue("LocationController should have provided a location", 0 < locations.size());
-            assertEquals(70.4085697998, locations.get(0).getLongitude(), 0.000001);
-            assertEquals(34.4188940003, locations.get(0).getLatitude(), 0.000001);
+            Assert.assertTrue("LocationController should have provided a location", 0 < locations.size());
+            Assert.assertEquals(70.4085697998, locations.get(0).getLongitude(), 0.000001);
+            Assert.assertEquals(34.4188940003, locations.get(0).getLatitude(), 0.000001);
         }
         instance.pause();
     }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/MapControllerTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/MapControllerTest.java
@@ -24,7 +24,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
 /**
  * A test for the MapController class.
@@ -59,21 +59,21 @@ public class MapControllerTest {
         System.out.println("zoomOut");
         MapControllerImpl instance = new MapControllerImpl();
         instance.zoomToScale(15000, 0, 0);
-        assertEquals(15000, instance.getScale(), 0.0);
+        Assert.assertEquals(15000, instance.getScale(), 0.0);
         instance.zoomOut();
-        assertEquals(30000, instance.getScale(), 0.0);
+        Assert.assertEquals(30000, instance.getScale(), 0.0);
         instance.zoomOut();
-        assertEquals(60000, instance.getScale(), 0.0);
+        Assert.assertEquals(60000, instance.getScale(), 0.0);
         instance.zoomIn();
-        assertEquals(30000, instance.getScale(), 0.0);
+        Assert.assertEquals(30000, instance.getScale(), 0.0);
         for (int i = 0; i < 5; i++) {
             instance.zoomIn();
         }
-        assertEquals(937.5, instance.getScale(), 0.0);
+        Assert.assertEquals(937.5, instance.getScale(), 0.0);
         for (int i = 0; i < 6; i++) {
             instance.zoomOut();
         }
-        assertEquals(60000, instance.getScale(), 0.0);
+        Assert.assertEquals(60000, instance.getScale(), 0.0);
     }
 
     /**
@@ -83,17 +83,17 @@ public class MapControllerTest {
     public void testRotate() {
         MapController instance = new MapControllerImpl();
         instance.setRotation(0.0);
-        assertEquals(0, instance.getRotation(), 0.0);
+        Assert.assertEquals(0, instance.getRotation(), 0.0);
         instance.rotate(179);
-        assertEquals(179, instance.getRotation(), 0.0);
+        Assert.assertEquals(179, instance.getRotation(), 0.0);
         instance.rotate(2);
-        assertEquals(-179, instance.getRotation(), 0.0);
+        Assert.assertEquals(-179, instance.getRotation(), 0.0);
         instance.rotate(179);
-        assertEquals(0, instance.getRotation(), 0.0);
+        Assert.assertEquals(0, instance.getRotation(), 0.0);
         instance.rotate(-1);
-        assertEquals(-1, instance.getRotation(), 0.0);
+        Assert.assertEquals(-1, instance.getRotation(), 0.0);
         instance.rotate(-180);
-        assertEquals(179, instance.getRotation(), 0.0);
+        Assert.assertEquals(179, instance.getRotation(), 0.0);
     }
 
     /**
@@ -105,7 +105,7 @@ public class MapControllerTest {
         MapControllerImpl instance = new MapControllerImpl();
         instance.zoom(15000);
         instance.zoomToScale(30000, 0, 0);
-        assertEquals(30000, instance.getScale(), 0.0);
+        Assert.assertEquals(30000, instance.getScale(), 0.0);
     }
 
     /**
@@ -197,7 +197,7 @@ public class MapControllerTest {
 
                 };
             } catch (Exception e) {
-                fail("Couldn't create LocationController: " + e.getMessage());
+                Assert.fail("Couldn't create LocationController: " + e.getMessage());
                 return null;
             }
         }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/MessageControllerTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/MessageControllerTest.java
@@ -25,7 +25,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 import org.xml.sax.SAXException;
 
 public class MessageControllerTest {
@@ -58,7 +58,7 @@ public class MessageControllerTest {
 
             @Override
             public void geomessageReceived(Geomessage geomessage) {
-                fail("That text had no Geomessages!");
+                Assert.fail("That text had no Geomessages!");
             }
 
             @Override
@@ -77,7 +77,7 @@ public class MessageControllerTest {
         Thread.sleep(100);
         controller.removeListener(listener);
         controller.stopReceiving();
-        assertEquals(expected, result.message);
+        Assert.assertEquals(expected, result.message);
     }
     
     @Test
@@ -124,10 +124,10 @@ public class MessageControllerTest {
         Thread.sleep(100);
         controller.removeListener(listener);
         controller.stopReceiving();
-        assertEquals(expected, result.message);
-        assertEquals(2, result.geomessages.size());
-        assertEquals("3A1-001", result.geomessages.get("{3a752ef3-b085-41e8-993a-3ec39098fde2}").getProperty("uniquedesignation"));
-        assertEquals("3A2-002", result.geomessages.get("{48f54ca2-ae19-4de0-9fda-f8dd9b17adac}").getProperty("uniquedesignation"));
+        Assert.assertEquals(expected, result.message);
+        Assert.assertEquals(2, result.geomessages.size());
+        Assert.assertEquals("3A1-001", result.geomessages.get("{3a752ef3-b085-41e8-993a-3ec39098fde2}").getProperty("uniquedesignation"));
+        Assert.assertEquals("3A2-002", result.geomessages.get("{48f54ca2-ae19-4de0-9fda-f8dd9b17adac}").getProperty("uniquedesignation"));
     }
     
 }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/PositionReportControllerTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/PositionReportControllerTest.java
@@ -28,7 +28,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
 public class PositionReportControllerTest {
     
@@ -59,7 +59,7 @@ public class PositionReportControllerTest {
             messageController.startReceiving();
             controller = new PositionReportController(locController, messageController, USERNAME, VEHICLE_TYPE, UID, SIC);
         } catch (Throwable t) {
-            fail("Couldn't set up test: " + t.getMessage());
+            Assert.fail("Couldn't set up test: " + t.getMessage());
         }
     }
     
@@ -84,53 +84,53 @@ public class PositionReportControllerTest {
     @Test
     public void testEnabled() {
         System.out.println("testEnabled");
-        assertFalse(controller.isEnabled());
+        Assert.assertFalse(controller.isEnabled());
         controller.setEnabled(true);
-        assertTrue(controller.isEnabled());
+        Assert.assertTrue(controller.isEnabled());
         controller.setEnabled(false);
-        assertFalse(controller.isEnabled());
+        Assert.assertFalse(controller.isEnabled());
     }
 
     @Test
     public void testPeriod() {
         System.out.println("testPeriod");
-        assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
+        Assert.assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
         controller.setPeriod(3456);
-        assertEquals(3456, controller.getPeriod());
+        Assert.assertEquals(3456, controller.getPeriod());
         controller.setPeriod(-42);
-        assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
+        Assert.assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
         controller.setPeriod(PositionReportController.DEFAULT_PERIOD);
-        assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
+        Assert.assertEquals(PositionReportController.DEFAULT_PERIOD, controller.getPeriod());
     }
     
     @Test
     public void testUsername() {
         System.out.println("testUsername");
-        assertEquals(USERNAME, controller.getUsername());
+        Assert.assertEquals(USERNAME, controller.getUsername());
         controller.setUsername("Woody");
-        assertEquals("Woody", controller.getUsername());
+        Assert.assertEquals("Woody", controller.getUsername());
         controller.setUsername(USERNAME);
-        assertEquals(USERNAME, controller.getUsername());
+        Assert.assertEquals(USERNAME, controller.getUsername());
     }
     
     @Test
     public void testVehicleType() {
         System.out.println("testVehicleType");
-        assertEquals(VEHICLE_TYPE, controller.getVehicleType());
+        Assert.assertEquals(VEHICLE_TYPE, controller.getVehicleType());
         controller.setVehicleType("SR-71");
-        assertEquals("SR-71", controller.getVehicleType());
+        Assert.assertEquals("SR-71", controller.getVehicleType());
         controller.setVehicleType(VEHICLE_TYPE);
-        assertEquals(VEHICLE_TYPE, controller.getVehicleType());
+        Assert.assertEquals(VEHICLE_TYPE, controller.getVehicleType());
     }
     
     @Test
     public void testUniqueId() {
         System.out.println("testUniqueId");
-        assertEquals(UID, controller.getUniqueId());
+        Assert.assertEquals(UID, controller.getUniqueId());
         controller.setUniqueId("Percy");
-        assertEquals("Percy", controller.getUniqueId());
+        Assert.assertEquals("Percy", controller.getUniqueId());
         controller.setUniqueId(UID);
-        assertEquals(UID, controller.getUniqueId());
+        Assert.assertEquals(UID, controller.getUniqueId());
     }
     
     @Test
@@ -159,8 +159,8 @@ public class PositionReportControllerTest {
              * the username. Someone could add code to do a more rigorous test, realizing
              * that elements won't be in any particular order in the XML message.
              */
-            assertNotNull(result.message);
-            assertTrue(0 < result.message.indexOf(">" + USERNAME + "<"));
+            Assert.assertNotNull(result.message);
+            Assert.assertTrue(0 < result.message.indexOf(">" + USERNAME + "<"));
         }
         controller.getMessageController().removeListener(listener);
     }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/SpotReportControllerTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/controller/test/SpotReportControllerTest.java
@@ -32,7 +32,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SpotReportControllerTest {
@@ -130,7 +130,7 @@ public class SpotReportControllerTest {
 
                 };
             } catch (Exception e) {
-                fail("Couldn't create LocationController: " + e.getMessage());
+                Assert.fail("Couldn't create LocationController: " + e.getMessage());
                 return null;
             }
         }
@@ -177,7 +177,7 @@ public class SpotReportControllerTest {
             MessageController messageController = new MessageController(PORT);
             controller = new SpotReportController(mapController, messageController);
         } catch (Throwable t) {
-            fail("Couldn't set up test: " + t.getMessage());
+            Assert.fail("Couldn't set up test: " + t.getMessage());
         }
     }
     
@@ -239,8 +239,8 @@ public class SpotReportControllerTest {
              * the username. Someone could add code to do a more rigorous test, realizing
              * that elements won't be in any particular order in the XML message.
              */
-            assertNotNull(result.message);
-            assertTrue(0 < result.message.indexOf(">" + USERNAME + "<"));
+            Assert.assertNotNull(result.message);
+            Assert.assertTrue(0 < result.message.indexOf(">" + USERNAME + "<"));
         }
     }
         

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/model/test/LocationTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/model/test/LocationTest.java
@@ -21,7 +21,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
 /**
  * A test for the Location class.
@@ -56,11 +56,11 @@ public class LocationTest {
         System.out.println("getSpeed");
         Location instance = new Location();
         instance.setSpeedMph(55);
-        assertEquals(24.587, instance.getSpeed(), 0.001);
-        assertEquals(55, instance.getSpeedMph(), 0);
+        Assert.assertEquals(24.587, instance.getSpeed(), 0.001);
+        Assert.assertEquals(55, instance.getSpeedMph(), 0);
         instance.setSpeed(55);
-        assertEquals(55, instance.getSpeed(), 0);
-        assertEquals(123.031, instance.getSpeedMph(), 0.001);
+        Assert.assertEquals(55, instance.getSpeed(), 0);
+        Assert.assertEquals(123.031, instance.getSpeedMph(), 0.001);
     }
     
 }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/model/test/RestServiceReaderTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/model/test/RestServiceReaderTest.java
@@ -21,7 +21,7 @@ import com.esri.militaryapps.model.LayerType;
 import com.esri.militaryapps.model.RestServiceReader;
 import java.net.URL;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
 /**
  * A test for the RestServiceReader class.
@@ -49,11 +49,11 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = true;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(1, result.length);
-            assertEquals(urlString, result[0].getDatasetPath());
-            assertEquals(LayerType.TILED_MAP_SERVICE, result[0].getLayerType());
-            assertTrue(result[0] instanceof BasemapLayerInfo);
-            assertEquals("World Topographic Map", result[0].getName());
+            Assert.assertEquals(1, result.length);
+            Assert.assertEquals(urlString, result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.TILED_MAP_SERVICE, result[0].getLayerType());
+            Assert.assertTrue(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("World Topographic Map", result[0].getName());
         }
         
         urlString = "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer";
@@ -63,11 +63,11 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = false;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(1, result.length);
-            assertEquals(urlString, result[0].getDatasetPath());
-            assertEquals(LayerType.TILED_MAP_SERVICE, result[0].getLayerType());
-            assertFalse(result[0] instanceof BasemapLayerInfo);
-            assertEquals("World Topographic Map", result[0].getName());
+            Assert.assertEquals(1, result.length);
+            Assert.assertEquals(urlString, result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.TILED_MAP_SERVICE, result[0].getLayerType());
+            Assert.assertFalse(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("World Topographic Map", result[0].getName());
         }
         
         urlString = "http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer";
@@ -77,11 +77,11 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = true;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(1, result.length);
-            assertEquals(urlString, result[0].getDatasetPath());
-            assertEquals(LayerType.DYNAMIC_MAP_SERVICE, result[0].getLayerType());
-            assertTrue(result[0] instanceof BasemapLayerInfo);
-            assertEquals("USA_Data", result[0].getName());
+            Assert.assertEquals(1, result.length);
+            Assert.assertEquals(urlString, result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.DYNAMIC_MAP_SERVICE, result[0].getLayerType());
+            Assert.assertTrue(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("USA_Data", result[0].getName());
         }
 
         urlString = "http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/HomelandSecurity/operations/FeatureServer/2";
@@ -91,11 +91,11 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = false;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(1, result.length);
-            assertEquals(urlString, result[0].getDatasetPath());
-            assertEquals(LayerType.FEATURE_SERVICE, result[0].getLayerType());
-            assertFalse(result[0] instanceof BasemapLayerInfo);
-            assertEquals("Incident Areas", result[0].getName());
+            Assert.assertEquals(1, result.length);
+            Assert.assertEquals(urlString, result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.FEATURE_SERVICE, result[0].getLayerType());
+            Assert.assertFalse(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("Incident Areas", result[0].getName());
         }
 
         urlString = "http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/HomelandSecurity/operations/FeatureServer";
@@ -106,19 +106,19 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = false;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(3, result.length);
-            assertEquals(urlString + notSep + "0", result[0].getDatasetPath());
-            assertEquals(LayerType.FEATURE_SERVICE, result[0].getLayerType());
-            assertFalse(result[0] instanceof BasemapLayerInfo);
-            assertEquals("Incident Points", result[0].getName());        
-            assertEquals(urlString + notSep + "1", result[1].getDatasetPath());
-            assertEquals(LayerType.FEATURE_SERVICE, result[1].getLayerType());
-            assertFalse(result[0] instanceof BasemapLayerInfo);
-            assertEquals("Incident Lines", result[1].getName());        
-            assertEquals(urlString + notSep + "2", result[2].getDatasetPath());
-            assertEquals(LayerType.FEATURE_SERVICE, result[2].getLayerType());
-            assertFalse(result[2] instanceof BasemapLayerInfo);
-            assertEquals("Incident Areas", result[2].getName());
+            Assert.assertEquals(3, result.length);
+            Assert.assertEquals(urlString + notSep + "0", result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.FEATURE_SERVICE, result[0].getLayerType());
+            Assert.assertFalse(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("Incident Points", result[0].getName());        
+            Assert.assertEquals(urlString + notSep + "1", result[1].getDatasetPath());
+            Assert.assertEquals(LayerType.FEATURE_SERVICE, result[1].getLayerType());
+            Assert.assertFalse(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("Incident Lines", result[1].getName());        
+            Assert.assertEquals(urlString + notSep + "2", result[2].getDatasetPath());
+            Assert.assertEquals(LayerType.FEATURE_SERVICE, result[2].getLayerType());
+            Assert.assertFalse(result[2] instanceof BasemapLayerInfo);
+            Assert.assertEquals("Incident Areas", result[2].getName());
         }
         
         urlString = "http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/CaliforniaDEM/ImageServer";
@@ -128,11 +128,11 @@ public class RestServiceReaderTest {
             url = new URL(urlString);
             useAsBasemap = false;
             result = RestServiceReader.readService(url, useAsBasemap);
-            assertEquals(1, result.length);
-            assertEquals(urlString, result[0].getDatasetPath());
-            assertEquals(LayerType.IMAGE_SERVICE, result[0].getLayerType());
-            assertFalse(result[0] instanceof BasemapLayerInfo);
-            assertEquals("SRTMCalifornia.tif", result[0].getName());
+            Assert.assertEquals(1, result.length);
+            Assert.assertEquals(urlString, result[0].getDatasetPath());
+            Assert.assertEquals(LayerType.IMAGE_SERVICE, result[0].getLayerType());
+            Assert.assertFalse(result[0] instanceof BasemapLayerInfo);
+            Assert.assertEquals("SRTMCalifornia.tif", result[0].getName());
         }
 
     }

--- a/source/MilitaryAppsLibrary/test/com/esri/militaryapps/util/test/UtilitiesTest.java
+++ b/source/MilitaryAppsLibrary/test/com/esri/militaryapps/util/test/UtilitiesTest.java
@@ -24,7 +24,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
 /**
  * A test for the Utilities class.
@@ -59,42 +59,42 @@ public class UtilitiesTest {
         double trigHeadingRadians = 0.0;
         double expResult = Math.PI / 2.0;
         double result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         trigHeadingRadians = Math.PI / 4.0;
         expResult = Math.PI / 4.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = Math.PI / 2.0;
         expResult = 0.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = 3 * Math.PI / 4.0;
         expResult = 7 * Math.PI / 4.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = Math.PI;
         expResult = 3.0 * Math.PI / 2.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = 5 * Math.PI / 4.0;
         expResult = 5 * Math.PI / 4.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = 3 * Math.PI / 2.0;
         expResult = Math.PI;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
         
         trigHeadingRadians = 7 * Math.PI / 4.0;
         expResult = 3 * Math.PI / 4.0;
         result = Utilities.toCompassHeadingRadians(trigHeadingRadians);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
     }
 
     /**
@@ -105,82 +105,82 @@ public class UtilitiesTest {
         //NW to NW
         double expResult = 307.7988889;
         double result = Utilities.calculateBearingDegrees(-74.0, 40.7, -172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NW to NE
         expResult = 315.425;
         result = Utilities.calculateBearingDegrees(-74.0, 40.7, 172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NW to SW
         expResult = 239.8547222;
         result = Utilities.calculateBearingDegrees(-74.0, 40.7, -172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NW to SE
         expResult = 245.8741667;
         result = Utilities.calculateBearingDegrees(-74.0, 40.7, 172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NE to NW
         expResult = 44.575;
         result = Utilities.calculateBearingDegrees(74.0, 40.7, -172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NE to NE
         expResult = 52.20111111;
         result = Utilities.calculateBearingDegrees(74.0, 40.7, 172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NE to SW
         expResult = 114.1258333;
         result = Utilities.calculateBearingDegrees(74.0, 40.7, -172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //NE to SE
         expResult = 120.1452778;
         result = Utilities.calculateBearingDegrees(74.0, 40.7, 172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SW to NW
         expResult = 300.1452778;
         result = Utilities.calculateBearingDegrees(-74.0, -40.7, -172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SW to NE
         expResult = 294.1258333;
         result = Utilities.calculateBearingDegrees(-74.0, -40.7, 172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SW to SW
         expResult = 232.2011111;
         result = Utilities.calculateBearingDegrees(-74.0, -40.7, -172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SW to SE
         expResult = 224.575;
         result = Utilities.calculateBearingDegrees(-74.0, -40.7, 172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SE to NW
         expResult = 65.87416667;
         result = Utilities.calculateBearingDegrees(74.0, -40.7, -172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SE to NE
         expResult = 59.85472222;
         result = Utilities.calculateBearingDegrees(74.0, -40.7, 172.5, 41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SE to SW
         expResult = 135.425;
         result = Utilities.calculateBearingDegrees(74.0, -40.7, -172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
 
         //SE to SE
         expResult = 127.7988889;
         result = Utilities.calculateBearingDegrees(74.0, -40.7, 172.5, -41.5);
-        assertEquals(expResult, result, 0.001);
+        Assert.assertEquals(expResult, result, 0.001);
     }
 
     /**
@@ -191,27 +191,27 @@ public class UtilitiesTest {
         System.out.println("fixAngleDegrees");
         double expResult = 123;
         double result = Utilities.fixAngleDegrees(123, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         expResult = 0;
         result = Utilities.fixAngleDegrees(0, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         expResult = 360;
         result = Utilities.fixAngleDegrees(360, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         expResult = 1;
         result = Utilities.fixAngleDegrees(361, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         expResult = 360;
         result = Utilities.fixAngleDegrees(720, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
 
         expResult = 359;
         result = Utilities.fixAngleDegrees(-1, 0, 360);
-        assertEquals(expResult, result, 0.0);
+        Assert.assertEquals(expResult, result, 0.0);
     }
 
     /**
@@ -222,27 +222,27 @@ public class UtilitiesTest {
         int colorRgb = Color.BLUE.getRGB();
         String expResult = "3";
         String result = Utilities.getAFMGeoEventColorString(colorRgb);
-        assertEquals(expResult, result);
+        Assert.assertEquals(expResult, result);
         
         colorRgb = Color.YELLOW.getRGB();
         expResult = "4";
         result = Utilities.getAFMGeoEventColorString(colorRgb);
-        assertEquals(expResult, result);
+        Assert.assertEquals(expResult, result);
         
         colorRgb = Color.GREEN.getRGB();
         expResult = "2";
         result = Utilities.getAFMGeoEventColorString(colorRgb);
-        assertEquals(expResult, result);
+        Assert.assertEquals(expResult, result);
         
         colorRgb = Color.RED.getRGB();
         expResult = "1";
         result = Utilities.getAFMGeoEventColorString(colorRgb);
-        assertEquals(expResult, result);
+        Assert.assertEquals(expResult, result);
         
         colorRgb = 0x002255;
         expResult = "#002255";
         result = Utilities.getAFMGeoEventColorString(colorRgb);
-        assertEquals(expResult, result);
+        Assert.assertEquals(expResult, result);
     }
     
     @Test
@@ -255,49 +255,49 @@ public class UtilitiesTest {
         input = "42SXD1234";
         expected = input;
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Remove non-alphanumeric
         input = "42S XD: 123, 456";
         expected = "42SXD123456";
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Add grid zone from reference MGRS
         input = "XD123456";
         expected = "42SXD123456";
         referenceMgrs = "42SXD567890";
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Leave alone a good string starting with A, B, Y, or Z
         input = "YXW456789";
         expected = "YXW456789";
         referenceMgrs = "12ABC567890";
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Strip leading digits off of a polar string (starting with A, B, Y, or Z)
         input = "12ABC456789";
         expected = "ABC456789";
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Reject a non-polar string without digits on the front
         input = "CBC456789";
         expected = null;
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Reject a bad grid zone number
         input = "62SXD1234";
         expected = null;
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
         
         //Return null if there are an odd number of easting/northing digits
         input = "42SXD12345";
         expected = null;
         referenceMgrs = null;
-        assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
+        Assert.assertEquals(expected, Utilities.convertToValidMgrs(input, referenceMgrs));
     }
     
     @Test
@@ -308,17 +308,17 @@ public class UtilitiesTest {
         input = "2013-10-11T13:34:40.4567-05:00";
         try {
             output = Utilities.parseXmlDateTime(input);
-            assertEquals(2013, output.get(Calendar.YEAR));
+            Assert.assertEquals(2013, output.get(Calendar.YEAR));
             //In Java Calendar, month is zero-based, so subtract one
-            assertEquals(10 - 1, output.get(Calendar.MONTH));
-            assertEquals(11, output.get(Calendar.DAY_OF_MONTH));
-            assertEquals(13, output.get(Calendar.HOUR_OF_DAY));
-            assertEquals(34, output.get(Calendar.MINUTE));
-            assertEquals(40, output.get(Calendar.SECOND));
-            assertEquals(457, output.get(Calendar.MILLISECOND));
-            assertEquals(TimeZone.getTimeZone("-05:00"), output.getTimeZone());
+            Assert.assertEquals(10 - 1, output.get(Calendar.MONTH));
+            Assert.assertEquals(11, output.get(Calendar.DAY_OF_MONTH));
+            Assert.assertEquals(13, output.get(Calendar.HOUR_OF_DAY));
+            Assert.assertEquals(34, output.get(Calendar.MINUTE));
+            Assert.assertEquals(40, output.get(Calendar.SECOND));
+            Assert.assertEquals(457, output.get(Calendar.MILLISECOND));
+            Assert.assertEquals(TimeZone.getTimeZone("-05:00"), output.getTimeZone());
         } catch (Exception ex) {
-            fail("Couldn't parse string: " + ex.getMessage());
+            Assert.fail("Couldn't parse string: " + ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
By default, NetBeans uses `import static org.junit.Assert.*;` for unit tests. Here we remove the import on demand and make it `import org.junit.Assert;` instead, then we call e.g. `Assert.assertEquals` instead of `assertEquals`.
