### PR TITLE
Checking for GeoMessage ID first

### DIFF
--- a/source/MilitaryAppsLibrary/src/com/esri/militaryapps/controller/AdvancedSymbolController.java
+++ b/source/MilitaryAppsLibrary/src/com/esri/militaryapps/controller/AdvancedSymbolController.java
@@ -248,9 +248,11 @@ public abstract class AdvancedSymbolController {
                 }
             }
             if ("remove".equalsIgnoreCase((String) geomessage.getProperty(getActionPropertyName()))) {
-                removeSpotReportGraphic(spotReportIdToGraphicId.get(geomessage.getId()));
-                synchronized (spotReportIdToGraphicId) {
-                    spotReportIdToGraphicId.remove(geomessage.getId());
+                if (spotReportIdToGraphicId.containsKey(geomessage.getId())) {
+                    removeSpotReportGraphic(spotReportIdToGraphicId.get(geomessage.getId()));
+                    synchronized (spotReportIdToGraphicId) {
+                        spotReportIdToGraphicId.remove(geomessage.getId());
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Otherwise, if it is not present, we get a NullPointerException when the
int gets autoboxed to an Integer.