### PR TITLE
Setting viewshed properties if elevation is not null

### DIFF
--- a/source/MilitaryAppsLibrary/src/com/esri/militaryapps/model/MapConfigReader.java
+++ b/source/MilitaryAppsLibrary/src/com/esri/militaryapps/model/MapConfigReader.java
@@ -325,7 +325,7 @@ public class MapConfigReader {
             mapConfig.setRotation(handler.rotation);
         }
         
-        if (null != handler.servicePath) {
+        if (null != handler.servicePath && null != handler.elevation) {
             mapConfig.setViewshedElevationPath(handler.elevation);
             if (null != handler.observerHeight) {
                 mapConfig.setViewshedObserverHeight(handler.observerHeight);


### PR DESCRIPTION
Previously we were only setting viewshed properties if servicePath was
not null. This change allows us to read the config properly for visual
analysis (i.e. raster dataset) and not just geoprocessing analysis (i.e.
geoprocessing package).